### PR TITLE
Update log4j 2.17.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <cucumber.version>6.1.2</cucumber.version>
         <lombok.version>1.18.20</lombok.version>
         <javafaker.version>1.0.2</javafaker.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <allure.version>2.13.5</allure.version>
         <allure-maven.version>2.10.0</allure-maven.version>
         <allure-environment-writer.version>1.0.0</allure-environment-writer.version>


### PR DESCRIPTION
Please refer to the articles below:

- https://securityaffairs.co/wordpress/126135/hacking/new-apache-log4j-cve-2021-44832.html

- https://snyk.io/blog/new-log4j-2-17-1-fixes-cve-2021-44832-remote-code-execution-but-its-not-as-bad-as-it-sounds/